### PR TITLE
Tweak for v0.14 compatible layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+
+rvm:
+  - 2.1
+  - 2.2
+  - 2.3.5
+  - 2.4.2
+
+gemfile:
+ - Gemfile
+
+script: bundle exec rake test
+sudo: false

--- a/fluent-plugin-time_parser.gemspec
+++ b/fluent-plugin-time_parser.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'fluentd'
   gem.add_development_dependency 'tzinfo'
+  gem.add_development_dependency 'test-unit', '~> 3.2'
   gem.add_runtime_dependency     'tzinfo'
   gem.add_runtime_dependency     'fluentd'
 end

--- a/lib/fluent/plugin/out_time_parser.rb
+++ b/lib/fluent/plugin/out_time_parser.rb
@@ -6,6 +6,11 @@ module Fluent
     include Fluent::HandleTagNameMixin
     Fluent::Plugin.register_output('time_parser', self)
 
+    # Define `router` method of v0.12 to support v0.10 or earlier
+    unless method_defined?(:router)
+      define_method("router") { Fluent::Engine }
+    end
+
     config_param :key, :string, :default => 'time'
     config_param :time_zone, :string, :default => ''
     config_param :parsed_time_tag, :string, :default => 'parsed_time'
@@ -36,7 +41,7 @@ module Fluent
       es.each {|time,record|
         t = tag.dup
         filter_record(t, time, record)
-        Engine.emit(t, time, record)
+        router.emit(t, time, record)
       }
       chain.next
     end


### PR DESCRIPTION
Since v0.14, `Engine.emit` had been treated as a bug.
We should use `router#emit` instead.