### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Will take a time attribute and will extract the date and the hour for a given ti
   type time_parser
 
   key            time
-  add_tag_prefix extracted.
+  tag extracted.${tag}
   time_zone      Asia/Tokyo
 </match>
 ```
@@ -43,11 +43,13 @@ Then you'll get re-emmited tags/records like so:
 
 `key` is used to point a key whose value contains the time you want to parse.
 
-### remove_tag_prefix, remove_tag_suffix, add_tag_prefix, add_tag_suffix
+### tag
 
-These params are included from `Fluent::HandleTagNameMixin`. See the code for details.
+In this param, users can write placeholders.
 
-You must add at least one of these params.
+Please use placeholders ${tag}, ${tag[0]}, ${tag[1]} in configuration.
+
+Note that `Fluent::HandleTagNameMixin` dependency is removed in v0.14 style of this plugin.
 
 ### time_zone
 

--- a/fluent-plugin-time_parser.gemspec
+++ b/fluent-plugin-time_parser.gemspec
@@ -13,9 +13,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'fluentd'
   gem.add_development_dependency 'tzinfo'
   gem.add_development_dependency 'test-unit', '~> 3.2'
   gem.add_runtime_dependency     'tzinfo'
-  gem.add_runtime_dependency     'fluentd'
+  gem.add_runtime_dependency     'fluentd', ['>= 0.14.0', '< 2']
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/output'
 
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new
@@ -18,4 +20,5 @@ end
 require 'fluent/plugin/out_time_parser'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change and also includes in breaking changes.

I have a few questions for v0.14 migrations:

* Should we convert buffered plugin from non-buffered?
  * Because `#extract_placeholders` feature will be permit in buffered output plugin. (chunk.metadata is needed in `#extract_placeholders`)
* I recommend to avoid to use `Fluent::HandleTagNameMixin`. Instead, I recommend to use tag parameter with placeholders
  * Is it acceptable for you?

---

If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.